### PR TITLE
FIX: documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ removed.  This is used as the prefix for the name of all containers in the pod.
 Some aspects of `moby-derp`'s operation are security-sensitive, and thus shouldn't
 be able to be modified by the ordinary user.  There is a
 system-wide configuration file for this purpose, by default located at
-`/etc/moby-derp.yml`.
+`/etc/moby-derp.conf`.
 
 Its structure is quite simple.  A full example looks like this:
 

--- a/example.yml
+++ b/example.yml
@@ -322,8 +322,8 @@ expose:
 # in the `moby-derp` README).
 #
 publish:
-  - :80
-  - :1234-1237
+  - ":80"
+  - ":1234-1237"
 
 # If you have a burning desire to have all exposed ports automatically published
 # to (not-so-)randomly chosen ephemeral ports, you can set this option to `true`.


### PR DESCRIPTION
* systemwide config file is /etc/moby-derp.conf not .yml
* using an unquoted port make Psych blow up when trying to load the YAML:
  "Tried to load unspecified class: Symbol (Psych::DisallowedClass)"