### PR TITLE
Set the hostname on the container

### DIFF
--- a/lib/moby_derp/container.rb
+++ b/lib/moby_derp/container.rb
@@ -85,6 +85,7 @@ module MobyDerp
 		def container_creation_parameters
 			{}.tap do |params|
 				if @root_container
+					params["Hostname"] = @pod.hostname
 					params["HostConfig"] = {
 						"NetworkMode" => @pod.network_name,
 						"Init"        => true,

--- a/spec/moby_derp/pod_spec.rb
+++ b/spec/moby_derp/pod_spec.rb
@@ -23,6 +23,7 @@ describe MobyDerp::Pod do
 		allow(pod_config).to receive(:root_labels).and_return({})
 		allow(pod_config).to receive(:common_environment).and_return({})
 		allow(pod_config).to receive(:expose).and_return([])
+		allow(pod_config).to receive(:hostname).and_return("test-test")
 		allow(Docker::Container).to receive(:get).and_raise(Docker::Error::NotFoundError)
 		allow(Docker::Container).to receive(:create).and_return(mock_docker_container)
 		allow(mock_docker_container).to receive(:start!).and_return(mock_docker_container)


### PR DESCRIPTION
The fact that this was omitted seems to have been an oversight.