### PR TITLE
Add host_hostname system config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ The keys are:
   "localhost"; so pointing to your local caching resolver using `127.0.0.1`
   will not end in happiness and puppies.
 
+* **`host_hostname`**: the hostname to use when generating the container
+  hostname. This might be useful, for example, if moby-derp is running
+  in a container by itself, with a hostname that reflects its management
+  function, but the containers that are managed conceptually belong to
+  the host.
+
 If you wish to modify the location of the `moby-derp` system-wide configuration
 file, you can do so by setting the `MOBY_DERP_SYSTEM_CONFIG_FILE` environment
 variable.  Note, however, that it is a terrible idea to let ordinary users control

--- a/lib/moby_derp/pod_config.rb
+++ b/lib/moby_derp/pod_config.rb
@@ -57,8 +57,8 @@ module MobyDerp
 			@containers = @config.fetch("containers")
 			validate_containers
 
-			@logger.debug(logloc) { "Hostname is #{Socket.gethostname}" }
-			@hostname = @config.fetch("hostname", "#{@name.gsub("_", "-")}-#{Socket.gethostname}")
+			@logger.debug(logloc) { "Hostname is #{@system_config.host_hostname}" }
+			@hostname = @config.fetch("hostname", "#{@name.gsub("_", "-")}-#{@system_config.host_hostname}")
 
 			@common_environment = @config.fetch("common_environment", {})
 			@common_labels      = @config.fetch("common_labels", {})

--- a/lib/moby_derp/system_config.rb
+++ b/lib/moby_derp/system_config.rb
@@ -1,9 +1,11 @@
 require_relative "./config_file"
 
+require "socket"
+
 module MobyDerp
 	class SystemConfig < ConfigFile
 		attr_reader :mount_root, :port_whitelist, :network_name, :use_host_resolv_conf,
-		            :cpu_count, :cpu_bits
+		            :cpu_count, :cpu_bits, :host_hostname
 
 		def initialize(config_data_or_filename, moby_info, logger)
 			@logger = logger
@@ -17,6 +19,7 @@ module MobyDerp
 				raise ArgumentError, "Unsupported type for config_data_or_filename parameter"
 			end
 
+			@host_hostname        = @config["host_hostname"] || Socket.gethostname
 			@mount_root           = @config["mount_root"]
 			@port_whitelist       = stringify_keys(@config["port_whitelist"] || {})
 			@network_name         = @config["network_name"] || "bridge"

--- a/spec/moby_derp/pod_config_spec.rb
+++ b/spec/moby_derp/pod_config_spec.rb
@@ -52,6 +52,7 @@ describe MobyDerp::PodConfig do
 		allow(system_config).to receive(:mount_root).and_return("/srv/docker")
 		allow(system_config).to receive(:port_whitelist).and_return({})
 		allow(system_config).to receive(:network_name).and_return("CBS")
+		allow(system_config).to receive(:host_hostname).and_return("speccy")
 		allow(system_config).to receive(:use_host_resolv_conf).and_return(false)
 		allow(system_config).to receive(:logger).and_return(logger)
 	end
@@ -87,7 +88,7 @@ describe MobyDerp::PodConfig do
 		end
 
 		it "sets a default hostname" do
-			expect(Socket).to receive(:gethostname).and_return("speccy")
+			expect(system_config).to receive(:host_hostname).and_return("speccy")
 
 			expect(pod_config.hostname).to eq("my-pod-speccy")
 		end
@@ -118,7 +119,7 @@ describe MobyDerp::PodConfig do
 		let(:config_filename) { "./my_pod.yml" }
 
 		it "translates the hostname to have a hyphen instead" do
-			expect(Socket).to receive(:gethostname).and_return("speccy")
+			expect(system_config).to receive(:host_hostname).and_return("speccy")
 
 			expect(pod_config.hostname).to eq("my-pod-speccy")
 		end

--- a/spec/moby_derp/system_config_spec.rb
+++ b/spec/moby_derp/system_config_spec.rb
@@ -48,6 +48,20 @@ describe MobyDerp::SystemConfig do
 		expect { MobyDerp::SystemConfig.new(42, moby_info, logger) }.to raise_error(ArgumentError)
 	end
 
+	it "uses the actual hostname by default for host_hostname" do
+		expect(Socket).to receive(:gethostname).and_return("batmobile")
+
+		expect(MobyDerp::SystemConfig.new(config_filename, moby_info, logger).host_hostname).to eq("batmobile")
+	end
+
+	context "with a host_hostname overide" do
+		let(:config_file_contents) { "mount_root: /tmp\nhost_hostname: overriden_value" }
+
+		it "uses the passed value" do
+			expect(MobyDerp::SystemConfig.new(config_filename, moby_info, logger).host_hostname).to eq("overriden_value")
+		end
+	end
+
 	context "with a port whitelist" do
 		let(:config_file_contents) { "mount_root: /tmp\nport_whitelist:\n  80: some-pod\n  443: some-pod" }
 


### PR DESCRIPTION
It's useful to be able to override the hostname that moby-derp uses in
the `PODNAME-HOSTNAME` scheme that it uses by default for container
hostnames instead of overriding the hostname in each pod.