### PR TITLE
Remove unhelpful check

### DIFF
--- a/lib/moby_derp/system_config.rb
+++ b/lib/moby_derp/system_config.rb
@@ -46,11 +46,6 @@ module MobyDerp
 				raise ConfigurationError,
 				      "use_host_resolv_conf must be true or false"
 			end
-
-			unless File.directory?(@mount_root)
-				raise ConfigurationError,
-				      "mount_root #{@mount_root} must exist and be a directory"
-			end
 		end
 
 		private

--- a/spec/moby_derp/system_config_spec.rb
+++ b/spec/moby_derp/system_config_spec.rb
@@ -97,8 +97,6 @@ describe MobyDerp::SystemConfig do
 			"mount_root:\n- one\n- two",
 		"when the mount_root specified in the config file isn't an absolute path" =>
 			"mount_root: relative/path",
-		"when the mount_root specified in the config file doesn't exist" =>
-			"mount_root: /this/directory/hopefully/doesnt/exist",
 		"when the specified config file isn't a YAML hash" =>
 			"42.5",
 		"when network_name isn't a string" =>


### PR DESCRIPTION
Since moby-derp may be running within a container and the mount_root is
a path within the host filesystem. This check isn't necessarily helpful.