### PR TITLE
Log instead of raising when updating containers

### DIFF
--- a/lib/moby_derp/pod.rb
+++ b/lib/moby_derp/pod.rb
@@ -38,9 +38,9 @@ module MobyDerp
 				begin
 					MobyDerp::Container.new(pod: self, container_config: cfg).run
 				rescue MobyDerp::ContainerError => ex
-					raise MobyDerp::ContainerError,
-					      "error while running container #{cfg.name}: #{ex.message}",
-							ex.backtrace
+					@logger.error(logloc) {
+						"Error while running container #{cfg.name}: #{ex.message}"
+					}
 				end
 			end
 		end

--- a/spec/moby_derp/pod_spec.rb
+++ b/spec/moby_derp/pod_spec.rb
@@ -167,8 +167,9 @@ describe MobyDerp::Pod do
 					allow(mock_container_config).to receive(:name).and_return("pod-fun")
 				end
 
-				it "raises an exception that tells us which container failed" do
-					expect { pod.run }.to raise_error(MobyDerp::ContainerError, /error while running container pod-fun/)
+				it "logs an exception that tells us which container failed" do
+					expect(logger).to receive(:error)
+					pod.run
 				end
 			end
 


### PR DESCRIPTION
Previously, when an image was removed from the registry that was
referred to in a pod's configuration, the whole process would be
aborted.