### PR TITLE
FEATURE: automatically start restart always containers

### DIFF
--- a/lib/moby_derp/container.rb
+++ b/lib/moby_derp/container.rb
@@ -29,6 +29,11 @@ module MobyDerp
 				if existing_container.info["Config"]["Labels"]["org.hezmatt.moby-derp.config-hash"] == params_hash(container_creation_parameters)
 					# Container is up-to-date
 					@logger.info(logloc) { "Container #{container_name} is up-to-date" }
+
+					if @config.restart == "always" && existing_container.info.dig("State", "Status") != "running"
+						existing_container.start
+					end
+
 					return existing_container.id
 				end
 

--- a/smoke_tests/restart_always.bats
+++ b/smoke_tests/restart_always.bats
@@ -1,0 +1,24 @@
+load test_helper
+
+@test "Restart always" {
+	config_file <<-'EOF'
+		containers:
+		  bob:
+		    image: busybox:latest
+		    command: sleep 600
+		    restart: always
+		common_labels:
+		  moby-derp-smoke-test: ayup
+EOF
+
+	run $MOBY_DERP_BIN $TEST_CONFIG_FILE
+
+	[ "$status" = "0" ]
+
+	docker stop mdst.bob
+	run $MOBY_DERP_BIN $TEST_CONFIG_FILE
+
+	echo $output
+	container_running "mdst"
+	container_running "mdst.bob"
+}


### PR DESCRIPTION
Previous to this change when running moby start containers would unconditionally
remain stopped.

This may be desirable if the operator stopped the container but is unlikely
desirable for "restart=always" containers.
