### PR TITLE
FIX: ensure root container has shareable ipc mode

### DIFF
--- a/lib/moby_derp/container.rb
+++ b/lib/moby_derp/container.rb
@@ -88,6 +88,7 @@ module MobyDerp
 					params["HostConfig"] = {
 						"NetworkMode" => @pod.network_name,
 						"Init"        => true,
+						"IpcMode"     => "shareable"
 					}
 					params["MacAddress"] = container_mac_address
 					if network_uses_ipv6? && user_defined_network?


### PR DESCRIPTION
Some docker setups may default to private ipc mode, breaking pod creation

Be explicit about the requirement for IpcMode shareable on pod root
